### PR TITLE
Fix Torrent Removal Bug

### DIFF
--- a/src/Core.cpp
+++ b/src/Core.cpp
@@ -80,12 +80,11 @@ void gt::Core::removeTorrent(shared_ptr<Torrent> t) {
     //TODO : add removal of files on request
     m_session.remove_torrent(t->getHandle());
     unsigned i;
-    for(i = 0;i<m_torrents.size();++i)
+    for(i = 0; i<m_torrents.size(); ++i)
         if(m_torrents[i] == t)
             break;
     cout <<endl << i << endl <<endl;
-    while(i < m_torrents.size()-1)
-    {
+    while(i < m_torrents.size()-1) {
         m_torrents[i] = m_torrents[i+1];
         ++i;
     }


### PR DESCRIPTION
The handles were not removed from `m_torrents` causing invalid handles to keep existing.
