### PR TITLE
Changed Core.cpp so that it should build on both windows and linux

### DIFF
--- a/src/Core.cpp
+++ b/src/Core.cpp
@@ -47,7 +47,11 @@ shared_ptr<gt::Torrent> gt::Core::addTorrent(string path, vector<char> *resumeda
 
 	libtorrent::error_code ec;
 	auto params = t->getTorrentParams();
+#ifdef _WIN32
+	params.resume_data = *resumedata; //TODO: Look if fast resume data exists for this torrent
+#else
 	params.resume_data = resumedata; //TODO: Look if fast resume data exists for this torrent
+#endif
 	libtorrent::torrent_handle h = m_session.add_torrent(params, ec);
 
 	if (ec.value() != 0)


### PR DESCRIPTION
This change allows gtorrent-core to be built on windows. Otherwise, the compiler throws an error: 

```
C:/msys32/home/Nick/gtorrent-ncurses/lib/gtorrent-core/src/Core.cpp:50:21: error: no match for 'operator=' (operand types are 'std::vector<char>' and 'std::vector<char>*')
  params.resume_data = resumedata; //TODO: Look if fast resume data exists for this torrent
```

NOTE: I have not tested this in any gui-kit, so I don't know whether this will affect functionality.
