### PR TITLE
Change ETA to 0 when torrent is paused

### DIFF
--- a/include/gtorrent/Torrent.hpp
+++ b/include/gtorrent/Torrent.hpp
@@ -52,10 +52,10 @@ namespace gt {
 		inline float getTotalProgress() { return ((float) getHandle().status().progress_ppm / 1000000.0f) * 100.0f; }
 
 		// Returns the current upload rate of the torrent
-		inline unsigned int getUploadRate() { return getHandle().status().upload_rate; }
+		inline unsigned int getUploadRate() { return (isPaused() ? 0 : getHandle().status().upload_rate); }
 
 		// Returns the current download rate of the torrent
-		inline unsigned int getDownloadRate() { return getHandle().status().download_rate; }
+		inline unsigned int getDownloadRate() { return (isPaused() ? 0 : getHandle().status().download_rate); }
 
 		// Returns the progress in PPM of all files downloading in this torrent
 		inline unsigned int getPPMProgress() { return getHandle().status().progress_ppm; }

--- a/src/Torrent.cpp
+++ b/src/Torrent.cpp
@@ -173,10 +173,7 @@ string gt::Torrent::getTextTotalRatio()
 void gt::Torrent::setPaused(bool isPaused)
 {
 	m_handle.auto_managed(!isPaused);
-	if (isPaused)
-		m_handle.pause();
-	else
-		m_handle.resume();
+        isPaused ? m_handle.pause() : m_handle.resume();
 }
 
 vector<bool> gt::Torrent::getPieces()


### PR DESCRIPTION
### Changes:
- ETA is 0 as soon as torrent is paused, instead of slowly decreasing
### Notes:
- [x] Builds
- [x] Tested by self
