### PR TITLE
Fixes the issue where gtorrent.lock is checked for even if the directory doesn't exist.

### DIFF
--- a/src/Platform_linux.cpp
+++ b/src/Platform_linux.cpp
@@ -152,6 +152,8 @@ bool gt::Platform::processIsUnique()
 	if(ld == -1)
 	{
 		gt::Log::Debug("The lock wasn't ready, retrying...");
+		if(!checkDirExist(getDefaultConfigPath()))
+			makeDir(getDefaultConfigPath(), 0755);
 		ld = open(string(getDefaultConfigPath() + "gtorrent.lock").c_str(), O_CREAT | O_RDWR, 0600);
 		return processIsUnique();
 	}


### PR DESCRIPTION
This is the simplest way I could think of to do this.
