### PR TITLE
Gtorrent-core now handles magnets and http links to torrent files.

### DIFF
--- a/include/gtorrent/Core.hpp
+++ b/include/gtorrent/Core.hpp
@@ -31,7 +31,7 @@ namespace gt
 
 		std::vector<std::shared_ptr<gt::Torrent>> &getTorrents();
 
-		static bool isMagnetLink(std::string const& link);
+		static bool isLink(std::string const& link);
 
 		int loadSession(std::string path);
 		int saveSession(std::string path);

--- a/src/Core.cpp
+++ b/src/Core.cpp
@@ -46,10 +46,10 @@ std::vector<std::shared_ptr<gt::Torrent>> &gt::Core::getTorrents()
 	return m_torrents;
 }
 
-bool gt::Core::isMagnetLink(std::string const& url)
+bool gt::Core::isLink(std::string const& url)
 {
-	const std::string prefix = "magnet:";
-	return url.compare(0, prefix.length(), prefix) == 0;
+	const std::string magprefix = "magnet:", httpprefix = "http:";
+	return url.compare(0, magprefix.length(), magprefix) == 0 || url.compare(0, httpprefix.length(), httpprefix) == 0;
 }
 
 std::shared_ptr<gt::Torrent> gt::Core::addTorrent(std::string path, std::vector<char> *resumedata)

--- a/src/Torrent.cpp
+++ b/src/Torrent.cpp
@@ -68,7 +68,7 @@ std::string getFileSizeString(int64_t file_size)
 gt::Torrent::Torrent(std::string path) : m_path(path)
 {
 	setSavePath(gt::Settings::settings["SavePath"]); //TODO add argument to allow user to override the default save path of $HOME/Downloads
-	if (gt::Core::isMagnetLink(path))
+	if (gt::Core::isLink(path))
 		m_torrent_params.url = path;
 	else
 	{


### PR DESCRIPTION
renamed isMagnetLink to isLink.

Is https supported in add_torrent_params.url?
reference says http URLs, but a parse_url.cpp exists in libtorrent, and it handles https.
